### PR TITLE
ci: fix invalid GitHub Actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,6 @@ updates:
       prefix: "ci"
       include: "scope"
     open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,16 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
 
     - name: Cache Gradle packages
-      uses: actions/cache@v5
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches
@@ -35,14 +35,14 @@ jobs:
       run: chmod +x gradlew
 
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v3
+      uses: gradle/wrapper-validation-action@v2
 
     - name: Run unit tests
       run: ./gradlew test --continue --no-daemon
       continue-on-error: true
 
     - name: Generate test report
-      uses: dorny/test-reporter@v2
+      uses: dorny/test-reporter@v1
       if: always()
       continue-on-error: true
       with:
@@ -57,16 +57,16 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
 
     - name: Cache Gradle packages
-      uses: actions/cache@v5
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches
@@ -79,14 +79,14 @@ jobs:
       run: chmod +x gradlew
 
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v3
+      uses: gradle/wrapper-validation-action@v2
 
     - name: Build with Gradle
       run: ./gradlew build --continue --no-daemon
       continue-on-error: true
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       if: always()
       continue-on-error: true
       with:
@@ -101,16 +101,16 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
 
     - name: Cache Gradle packages
-      uses: actions/cache@v5
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches
@@ -123,14 +123,14 @@ jobs:
       run: chmod +x gradlew
 
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v3
+      uses: gradle/wrapper-validation-action@v2
 
     - name: Run lint checks
       run: ./gradlew lint --continue --no-daemon
       continue-on-error: true
 
     - name: Upload lint results
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       if: always()
       continue-on-error: true
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       run: chmod +x gradlew
 
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v2
+      uses: gradle/actions/wrapper-validation@v4
 
     - name: Run unit tests
       run: ./gradlew test --continue --no-daemon

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -39,13 +39,13 @@ jobs:
         echo "ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}" >> $GITHUB_ENV
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         queries: security-and-quality
 
     - name: Cache Gradle packages
-      uses: actions/cache@v5
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches
@@ -58,12 +58,12 @@ jobs:
       run: chmod +x gradlew
 
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v3
+      uses: gradle/wrapper-validation-action@v2
       continue-on-error: true
 
     # Use autobuild for better compatibility
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@v3
       continue-on-error: true
       id: autobuild
 
@@ -80,7 +80,7 @@ jobs:
       continue-on-error: true
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@v3
       continue-on-error: true
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
       run: chmod +x gradlew
 
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v2
+      uses: gradle/actions/wrapper-validation@v4
       continue-on-error: true
 
     # Use autobuild for better compatibility


### PR DESCRIPTION
This PR fixes the CI pipeline by downgrading invalid GitHub Action versions (v6/v5) to the latest valid stable versions (v4/v3). It also updates the Dependabot configuration to ignore major version updates for actions to prevent future breakage.